### PR TITLE
fix: accept command response type tag

### DIFF
--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -105,6 +105,7 @@ schema. Do not include markdown or prose:
 
 ```json
 {{
+  "plan_type": "command_plan",
   "goal": "short operator goal",
   "commands": [
     {{

--- a/src/linuxagent/plans/models.py
+++ b/src/linuxagent/plans/models.py
@@ -120,6 +120,7 @@ class PlannedCommand(BaseModel):
 class CommandPlan(BaseModel):
     model_config = _FROZEN
 
+    plan_type: Literal["command_plan"] = "command_plan"
     goal: str = Field(min_length=1)
     commands: tuple[PlannedCommand, ...] = Field(min_length=1)
     risk_summary: str = ""
@@ -310,6 +311,7 @@ def command_plan_json(
 ) -> str:
     """Small helper for tests and harness fixtures."""
     plan: dict[str, Any] = {
+        "plan_type": "command_plan",
         "goal": goal,
         "commands": [
             {

--- a/tests/integration/test_agent_runtime.py
+++ b/tests/integration/test_agent_runtime.py
@@ -60,6 +60,7 @@ class _UI:
         self.response = {"decision": "yes", "latency_ms": 1} if response is None else response
         self.interrupts: list[dict[str, Any]] = []
         self.printed: list[str] = []
+        self.user_inputs: list[str] = []
         self.execution_results: list[ExecutionResult] = []
 
     async def input_stream(self) -> AsyncIterator[str]:
@@ -76,8 +77,14 @@ class _UI:
     async def print(self, text: str) -> None:
         self.printed.append(text)
 
+    async def print_user_input(self, text: str) -> None:
+        self.user_inputs.append(text)
+
     async def print_execution_result(self, result: ExecutionResult) -> None:
         self.execution_results.append(result)
+
+    def clear_activity(self) -> None:
+        return None
 
 
 def _router_response(mode: str, answer: str = "", reason: str = "test route") -> str:

--- a/tests/unit/plans/test_command_plan.py
+++ b/tests/unit/plans/test_command_plan.py
@@ -23,9 +23,28 @@ from linuxagent.plans import (
 def test_parse_command_plan_accepts_json_object() -> None:
     plan = parse_command_plan(command_plan_json("/bin/echo hi", goal="Say hi"))
 
+    assert plan.plan_type == "command_plan"
     assert plan.goal == "Say hi"
     assert plan.primary.command == "/bin/echo hi"
     assert plan.primary.read_only is True
+
+
+def test_parse_command_plan_accepts_legacy_json_without_plan_type() -> None:
+    payload = json.loads(command_plan_json("/bin/echo hi"))
+    del payload["plan_type"]
+
+    plan = parse_command_plan(json.dumps(payload))
+
+    assert plan.plan_type == "command_plan"
+    assert plan.primary.command == "/bin/echo hi"
+
+
+def test_parse_command_plan_rejects_wrong_plan_type() -> None:
+    payload = json.loads(command_plan_json("/bin/echo hi"))
+    payload["plan_type"] = "no_change"
+
+    with pytest.raises(CommandPlanParseError, match="plan_type"):
+        parse_command_plan(json.dumps(payload))
 
 
 def test_parse_command_plan_accepts_json_code_fence() -> None:


### PR DESCRIPTION
Fixes #14

Summary:
- accept the command response type tag while keeping older JSON compatible
- update the command execution prompt example to match parser behavior
- add regression coverage for tagged, legacy, and wrong-tag command JSON

Tests:
- focused parser tests
- make lint
- make type
- make test