### PR TITLE
Fix stable activity status display

### DIFF
--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -70,6 +70,13 @@ inline interpreter commands are acceptable only when they are necessary and
 readable in the confirmation panel. Keep commands separate when they require
 different risk levels, package-manager fallbacks, remote targets, or when one
 failure should not block independent results.
+For Ansible runtime inspection against an existing inventory, including paths
+such as `/etc/ansible/hosts`, treat the inventory path as a command input, not
+as a workspace file to edit. If the user asks to use ansible commands for a
+resource audit, inventory check, host group inspection, or result summary,
+return a CommandPlan with argv-safe `ansible` or `ansible-inventory` commands.
+Do not create, edit, or write playbooks under `/etc/ansible` unless the user
+explicitly asks to create or modify a playbook/config file there.
 When editing existing files or writing code against current repository content,
 inspect current content with the available read-only workspace tools before
 producing a FilePatchPlan. Follow each tool's declared input semantics instead

--- a/src/linuxagent/graph/intent_flow.py
+++ b/src/linuxagent/graph/intent_flow.py
@@ -165,18 +165,57 @@ async def _planned_outcome_update(
     current_trace_id: str,
     outcome: PlannedWork | AgentState,
     observed_tool_outputs: list[str],
+    *,
+    allow_file_patch_misroute_retry: bool = True,
 ) -> AgentState:
     if isinstance(outcome, DirectAnswerPlan):
         return direct_response_update(current_trace_id, outcome.answer)
     if isinstance(outcome, CommandPlan):
         return plan_update(current_trace_id, outcome, context.cluster_service)
     if isinstance(outcome, FilePatchPlan):
+        misroute_error = _ansible_runtime_file_patch_misroute(user_text, outcome)
+        if allow_file_patch_misroute_retry and misroute_error is not None:
+            recovered = await _retry_plan_or_error(
+                context,
+                messages,
+                user_text,
+                current_trace_id,
+                misroute_error,
+                outcome.model_dump_json(),
+            )
+            return await _planned_outcome_update(
+                context,
+                messages,
+                user_text,
+                current_trace_id,
+                recovered,
+                observed_tool_outputs,
+                allow_file_patch_misroute_retry=False,
+            )
         return file_patch_update(current_trace_id, outcome)
     if isinstance(outcome, NoChangePlan):
         return await _no_change_update(
             context, messages, user_text, current_trace_id, outcome, observed_tool_outputs
         )
     return outcome
+
+
+def _ansible_runtime_file_patch_misroute(user_text: str, plan: FilePatchPlan) -> str | None:
+    text = user_text.casefold()
+    if "ansible" not in text:
+        return None
+    if "playbook" in text:
+        return None
+    target_text = " ".join((*plan.files_changed, plan.unified_diff)).casefold()
+    if "/etc/ansible/playbooks" not in target_text and "playbook" not in target_text:
+        return None
+    return (
+        "Planner returned a FilePatchPlan for an Ansible runtime inspection request. "
+        "The user asked to use ansible commands against an existing inventory; treat "
+        "inventory paths such as /etc/ansible/hosts as command inputs. Do not create "
+        "or edit playbooks under /etc/ansible. Return a CommandPlan with argv-safe "
+        "ansible or ansible-inventory commands."
+    )
 
 
 async def _no_change_update(

--- a/src/linuxagent/ui/console.py
+++ b/src/linuxagent/ui/console.py
@@ -33,7 +33,7 @@ from .diff_renderer import (
 )
 from .prompt_session import PromptSessionManager, SlashCommandCompleter
 from .resume_selector import ResumeSelector
-from .working_status import WORKING_REFRESH_PER_SECOND, WorkingStatus
+from .working_status import WORKING_REFRESH_PER_SECOND, WorkingStatus, _working_label
 
 __all__ = ["ConsoleUI", "SlashCommandCompleter"]
 
@@ -60,6 +60,7 @@ class ConsoleUI(UserInterface):
         self._model = model
         self._activity_visible = True
         self._working_status: WorkingStatus | None = None
+        self._activity_started_at: float | None = None
         self._pending_inputs: tuple[str, ...] = ()
         self._owner_loop: asyncio.AbstractEventLoop | None = None
         self._cancel_event: asyncio.Event = asyncio.Event()
@@ -144,7 +145,7 @@ class ConsoleUI(UserInterface):
     async def print_raw(self, text: str, *, stderr: bool = False) -> None:
         if await self._run_on_owner_loop(lambda: self.print_raw(text, stderr=stderr)):
             return
-        self.clear_activity()
+        self._clear_activity(reset_timer=False)
         rendered = Text(text, style="red") if stderr else Text(text)
         self._print_to_current_stdout(rendered, end="")
 
@@ -155,7 +156,7 @@ class ConsoleUI(UserInterface):
             lambda: self.print_execution_result(result, include_output=include_output)
         ):
             return
-        self.clear_activity()
+        self._clear_activity(reset_timer=False)
         display = _execution_result_display(result, include_output=include_output)
         style = "green" if result.exit_code == 0 else "red"
         title = self._translator.t("ui.console.command_result_title", exit_code=result.exit_code)
@@ -166,18 +167,17 @@ class ConsoleUI(UserInterface):
             return
         if not self._activity_visible:
             return
-        working_prefix = self._translator.t("ui.working.activity_prefix")
-        if text.startswith(working_prefix) and sys.stdin.isatty() and self._console.is_terminal:
+        if self._is_transient_activity(text) and sys.stdin.isatty() and self._console.is_terminal:
             self.start_working(text)
             return
-        self.clear_activity()
+        self._clear_activity(reset_timer=False)
         self._print_to_current_stdout(Text(text, style="dim"))
 
     async def print_active_view(self, view: ActiveTurnView) -> None:
         if await self._run_on_owner_loop(lambda: self.print_active_view(view)):
             return
         if _terminal_active_view(view):
-            self.clear_activity()
+            self._clear_activity(reset_timer=False)
             return
         self._render_active_view(view)
 
@@ -189,12 +189,19 @@ class ConsoleUI(UserInterface):
             return
         if not sys.stdin.isatty() or not self._console.is_terminal:
             return
+        self._prompt_session.set_activity_busy(True)
+        now = time.monotonic()
+        if self._starts_new_activity_cycle(text) or self._activity_started_at is None:
+            self._activity_started_at = now
         if self._working_status is None:
             self._working_status = WorkingStatus(
                 self._console,
                 theme=self._theme,
                 translator=self._translator,
+                started_at=self._activity_started_at,
             )
+        else:
+            self._working_status.set_started_at(self._activity_started_at)
         self._working_status.update(text)
         self._working_status.update_pending_inputs(self._pending_inputs)
         self._ensure_working_refresh_task()
@@ -204,21 +211,51 @@ class ConsoleUI(UserInterface):
             return
         if not sys.stdin.isatty() or not self._console.is_terminal:
             return
+        if self._activity_started_at is None:
+            self._activity_started_at = time.monotonic()
         if self._working_status is None:
             self._working_status = WorkingStatus(
                 self._console,
                 theme=self._theme,
                 translator=self._translator,
+                started_at=self._activity_started_at,
             )
+        else:
+            self._working_status.set_started_at(self._activity_started_at)
         self._working_status.update_view(view)
         self._working_status.update_pending_inputs(self._pending_inputs)
         self._ensure_working_refresh_task()
 
     def clear_activity(self) -> None:
+        self._clear_activity(reset_timer=True)
+
+    def _clear_activity(self, *, reset_timer: bool) -> None:
         self._stop_working_refresh_task()
         if self._working_status is not None:
             self._working_status.stop()
             self._working_status = None
+        if reset_timer:
+            self._activity_started_at = None
+            self._prompt_session.set_activity_busy(False)
+
+    def _starts_new_activity_cycle(self, text: str) -> bool:
+        return _working_label(text, self._translator) == self._translator.t("ui.working.title")
+
+    def _is_transient_activity(self, text: str) -> bool:
+        if text.startswith(self._translator.t("ui.working.activity_prefix")):
+            return True
+        return any(text.startswith(prefix) for prefix in self._tool_failure_activity_prefixes())
+
+    def _tool_failure_activity_prefixes(self) -> tuple[str, ...]:
+        specs: tuple[tuple[str, dict[str, str]], ...] = (
+            ("runtime.tool.activity_guidance_failed", {"path": ""}),
+            ("runtime.tool.activity_read_failed", {"path": ""}),
+            ("runtime.tool.activity_list_failed", {"path": ""}),
+            ("runtime.tool.activity_search_failed", {"target": ""}),
+        )
+        return tuple(
+            prefix for key, params in specs if (prefix := self._translator.t(key, **params).strip())
+        )
 
     def _ensure_working_refresh_task(self) -> None:
         if self._working_refresh_task is not None and not self._working_refresh_task.done():
@@ -258,6 +295,8 @@ class ConsoleUI(UserInterface):
         if self._working_status is not None:
             self._working_status.cancel()
             self._working_status = None
+        self._activity_started_at = None
+        self._prompt_session.set_activity_busy(False)
 
     def _remove_pending_input(self, text: str) -> None:
         if not self._pending_inputs:

--- a/src/linuxagent/ui/prompt_session.py
+++ b/src/linuxagent/ui/prompt_session.py
@@ -39,6 +39,8 @@ class PromptSessionManager:
         self._session_factory = session_factory or self._default_session_factory
         self._cancel_event: Event | None = None
         self._cancel_reason_setter: Callable[[str], None] | None = None
+        self._activity_busy = False
+        self._active_session: Any | None = None
 
     def set_cancel_event(
         self, cancel_event: Event, reason_setter: Callable[[str], None] | None = None
@@ -47,7 +49,14 @@ class PromptSessionManager:
         self._cancel_reason_setter = reason_setter
 
     def create_session(self) -> Any:
-        return self._session_factory()
+        self._active_session = self._session_factory()
+        return self._active_session
+
+    def set_activity_busy(self, busy: bool) -> None:
+        if busy == self._activity_busy:
+            return
+        self._activity_busy = busy
+        self._invalidate_active_session()
 
     def dynamic_prompt(self, session: Any) -> Callable[[], list[tuple[str, str]]]:
         def prompt() -> list[tuple[str, str]]:
@@ -56,6 +65,8 @@ class PromptSessionManager:
         return prompt
 
     def build_prompt(self, current_text: str = "") -> list[tuple[str, str]]:
+        if self._activity_busy:
+            return []
         accent = "ansiblue" if self._theme == "light" else "ansibrightcyan"
         symbol_style = "ansibrightblack"
         if current_text.startswith("!"):
@@ -85,6 +96,12 @@ class PromptSessionManager:
             reserve_space_for_menu=8,
             key_bindings=self._key_bindings(),
         )
+
+    def _invalidate_active_session(self) -> None:
+        app = getattr(self._active_session, "app", None)
+        invalidate = getattr(app, "invalidate", None)
+        if callable(invalidate):
+            invalidate()
 
     def _key_bindings(self) -> KeyBindings:
         bindings = KeyBindings()

--- a/src/linuxagent/ui/working_status.py
+++ b/src/linuxagent/ui/working_status.py
@@ -16,7 +16,8 @@ from ..i18n import Translator, default_translator
 
 WORKING_REFRESH_PER_SECOND = 1
 ACTIVITY_INTERVAL_MS = 600
-MAX_ACTIVITY_ITEMS = 8
+MAX_ACTIVE_VIEW_ITEMS = 8
+MAX_STATUS_DETAIL_LINES = 3
 MAX_PENDING_INPUTS = 5
 
 
@@ -27,23 +28,23 @@ class WorkingStatus:
         *,
         theme: str = "auto",
         translator: Translator | None = None,
+        started_at: float | None = None,
     ) -> None:
         self._console = console
         self._theme = theme
         self._translator = translator or default_translator()
         self._live: Live | None = None
-        self._started_at = 0.0
+        self._started_at = started_at or 0.0
         self._message = self._working_title()
-        self._items: list[str] = []
-        self._omitted_count = 0
         self._pending_inputs: tuple[str, ...] = ()
         self._active_view: ActiveTurnView | None = None
+
+    def set_started_at(self, started_at: float) -> None:
+        self._started_at = started_at
 
     def update(self, message: str) -> None:
         self._active_view = None
         self._message = _working_label(message, self._translator)
-        if self._message != self._working_title():
-            self._append_item(self._message)
         self._refresh()
 
     def update_view(self, view: ActiveTurnView) -> None:
@@ -89,7 +90,8 @@ class WorkingStatus:
 
     def _refresh(self) -> None:
         if self._live is None or not self._live.is_started:
-            self._started_at = time.monotonic()
+            if self._started_at <= 0.0:
+                self._started_at = time.monotonic()
             with _console_stdout(self._console):
                 self._live = Live(
                     get_renderable=self._render,
@@ -107,41 +109,28 @@ class WorkingStatus:
 
     def _render_legacy_items(self) -> Text:
         title = self._working_title()
-        if not self._items:
+        if self._message == title:
             return self._render_title()
-        if len(self._items) == 1 and "\n" not in self._message:
-            elapsed = max(0, int(time.monotonic() - self._started_at))
-            suffix = self._translator.t("ui.working.suffix", elapsed=elapsed)
-            return Text.assemble(
-                (_activity_indicator(), self._accent_style()),
-                " ",
-                (title, "bold"),
-                (f": {self._message}", "bold") if self._message != title else "",
-                (suffix, "dim"),
-            )
-        text = self._render_title(stable=True)
-        visible_items = self._visible_items()
-        for index, item in enumerate(visible_items):
+
+        header, details = _split_activity_message(self._message)
+        text = self._render_title()
+        for item in [header, *details]:
             text.append("\n")
-            _append_render_item(text, item, current=index == len(visible_items) - 1)
+            _append_detail_item(text, item)
         return text
 
     def _render_active_view(self, view: ActiveTurnView) -> Text:
         items = _active_view_items(view)
-        text = self._render_title(stable=bool(items))
+        text = self._render_title()
         for item in items:
             text.append("\n")
             _append_render_item(text, _active_item_label(item), current=_active_item_current(item))
         return text
 
-    def _render_title(self, *, stable: bool = False) -> Text:
-        if stable:
-            indicator = "•"
-            suffix = self._translator.t("ui.working.stable_suffix")
-        else:
-            indicator = _activity_indicator()
-            elapsed = max(0, int(time.monotonic() - self._started_at))
-            suffix = self._translator.t("ui.working.suffix", elapsed=elapsed)
+    def _render_title(self) -> Text:
+        indicator = _activity_indicator()
+        elapsed = max(0, int(time.monotonic() - self._started_at))
+        suffix = self._translator.t("ui.working.suffix", elapsed=elapsed)
         return Text.assemble(
             (indicator, self._accent_style()),
             " ",
@@ -157,27 +146,8 @@ class WorkingStatus:
     def _working_title(self) -> str:
         return self._translator.t("ui.working.title")
 
-    def _append_item(self, message: str) -> None:
-        if self._items and self._items[-1] == message:
-            return
-        self._items.append(message)
-        if len(self._items) <= MAX_ACTIVITY_ITEMS:
-            return
-        self._items.pop(0)
-        self._omitted_count += 1
-
-    def _visible_items(self) -> list[str]:
-        if self._omitted_count <= 0:
-            return list(self._items)
-        omitted = self._translator.t("ui.working.omitted", count=self._omitted_count)
-        return [omitted, *self._items]
-
     def _periodic_refresh_allowed(self) -> bool:
-        if self._pending_inputs:
-            return False
-        if self._active_view is not None:
-            return not _active_view_items(self._active_view)
-        return len(self._items) <= 1 and "\n" not in self._message
+        return not self._pending_inputs
 
 
 def _working_label(message: str, translator: Translator) -> str:
@@ -197,6 +167,26 @@ def _activity_indicator() -> str:
     return "•" if tick % 2 == 0 else "◦"
 
 
+def _split_activity_message(message: str) -> tuple[str, list[str]]:
+    lines = [line.strip() for line in message.splitlines() if line.strip()]
+    if not lines:
+        return "", []
+    return lines[0], _limited_details(lines[1:])
+
+
+def _limited_details(lines: list[str]) -> list[str]:
+    if len(lines) <= MAX_STATUS_DETAIL_LINES:
+        return lines
+    visible = lines[:MAX_STATUS_DETAIL_LINES]
+    visible[-1] = f"{visible[-1]}..."
+    return visible
+
+
+def _append_detail_item(text: Text, item: str) -> None:
+    text.append("  └ ", style="dim")
+    text.append(item, style="dim")
+
+
 def _append_render_item(text: Text, item: str, *, current: bool) -> None:
     marker = "•" if current else "✓"
     style = "bold" if current else "dim"
@@ -209,7 +199,7 @@ def _append_render_item(text: Text, item: str, *, current: bool) -> None:
 
 
 def _active_view_items(view: ActiveTurnView) -> list[ActiveWorkItemView]:
-    return list(view.items[-MAX_ACTIVITY_ITEMS:])
+    return list(view.items[-MAX_ACTIVE_VIEW_ITEMS:])
 
 
 def _active_item_current(item: ActiveWorkItemView) -> bool:

--- a/tests/unit/graph/test_agent_graph.py
+++ b/tests/unit/graph/test_agent_graph.py
@@ -2314,6 +2314,32 @@ async def test_graph_ignores_unresolved_external_tool_targets(tmp_path) -> None:
     assert snapshot.values["execution_result"].stderr != "no matching cluster hosts selected"
 
 
+async def test_graph_retries_ansible_runtime_inspection_file_patch_as_command(tmp_path) -> None:
+    bad_patch = file_patch_plan_json(
+        "/etc/ansible/playbooks/system_check.yml",
+        "- hosts: yingxiaoyun-no-prod\n  tasks: []\n",
+    )
+    good_command = command_plan_json("ansible yingxiaoyun-no-prod -i /etc/ansible/hosts -m setup")
+    graph, provider = _graph(tmp_path, [bad_patch, good_command])
+    config = {"configurable": {"thread_id": "ansible-runtime-misroute"}}
+
+    await graph.ainvoke(
+        initial_state(
+            "使用ansible命令对yingxiaoyun-no-prod这个资源分组进行系统资源使用率巡检，"
+            "资源分组在这个主机清单文件中/etc/ansible/hosts，然后对巡检结果做下总结",
+            source=CommandSource.USER,
+        ),
+        config=config,
+    )
+
+    snapshot = await graph.aget_state(config)
+    assert snapshot.values["pending_command"] == (
+        "ansible yingxiaoyun-no-prod -i /etc/ansible/hosts -m setup"
+    )
+    assert snapshot.values.get("file_patch_plan") is None
+    assert _has_llm_call(provider, node="parse_intent", mode="planner_retry")
+
+
 async def test_graph_treats_localhost_target_as_local_execution(tmp_path) -> None:
     cfg = ClusterConfig(
         batch_confirm_threshold=2,

--- a/tests/unit/ui/test_console.py
+++ b/tests/unit/ui/test_console.py
@@ -21,6 +21,7 @@ from linuxagent.config.models import LanguageCode
 from linuxagent.i18n import Translator
 from linuxagent.interfaces import ExecutionResult
 from linuxagent.ui import ConsoleUI
+from linuxagent.ui import working_status as working_status_module
 from linuxagent.ui.console import SlashCommandCompleter
 from linuxagent.ui.working_status import WorkingStatus
 
@@ -719,25 +720,27 @@ async def test_console_print_activity_uses_transient_working_status(monkeypatch)
     await ui.print_activity("LinuxAgent 正在规划命令")
 
     assert ui._working_status is not None
+    assert ui._build_prompt() == []
     render_console = Console(record=True, width=120)
     render_console.print(ui._working_status._render())
     rendered = render_console.export_text()
-    assert "处理中: 规划命令" in rendered
+    assert "处理中（0s • esc 中断）" in rendered
+    assert "规划命令" in rendered
     assert "esc 中断" in rendered
     assert "╭" not in rendered
     assert "│" not in rendered
     assert "╰" not in rendered
-    assert "\n" not in rendered.rstrip("\n")
 
     await ui.print("done")
 
     assert ui._working_status is None
+    assert ui._build_prompt()
     final_rendered = console.export_text()
     assert "已完成步骤" not in final_rendered
     assert "规划命令" in final_rendered
 
 
-async def test_console_print_activity_keeps_cumulative_working_history(
+async def test_console_print_activity_keeps_current_working_status(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
@@ -751,8 +754,9 @@ async def test_console_print_activity_keeps_cumulative_working_history(
     render_console = Console(record=True, width=120)
     render_console.print(ui._working_status._render())
     rendered = render_console.export_text()
-    assert "分类意图" in rendered
+    assert "处理中（0s • esc 中断）" in rendered
     assert "规划命令" in rendered
+    assert "分类意图" not in rendered
     assert "esc 中断" in rendered
 
     await ui.print("done")
@@ -791,8 +795,7 @@ async def test_console_print_activity_supports_multiline_working_status(monkeypa
     render_console = Console(record=True, width=120)
     render_console.print(ui._working_status._render())
     rendered = render_console.export_text()
-    assert "处理中（esc 中断）" in rendered
-    assert "s • esc 中断" not in rendered
+    assert "处理中（0s • esc 中断）" in rendered
     assert "esc 中断" in rendered
     assert "整理文件 workspace/disk_info.sh" in rendered
     assert "read_file · 95 lines" in rendered
@@ -838,8 +841,7 @@ async def test_console_print_activity_shows_parallel_agent_group(monkeypatch) ->
     render_console = Console(record=True, width=120)
     render_console.print(ui._working_status._render())
     rendered = render_console.export_text()
-    assert "处理中（esc 中断）" in rendered
-    assert "s • esc 中断" not in rendered
+    assert "处理中（0s • esc 中断）" in rendered
     assert "esc 中断" in rendered
     assert "并发处理 只读批次：2/2" in rendered
     assert "agent A: running - 查 systemctl 状态" in rendered
@@ -848,6 +850,54 @@ async def test_console_print_activity_shows_parallel_agent_group(monkeypatch) ->
     await ui.print("done")
 
     assert ui._working_status is None
+
+
+async def test_console_print_activity_preserves_elapsed_after_tool_status_clear(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    now = 100.0
+    monkeypatch.setattr(console_module.time, "monotonic", lambda: now)
+    monkeypatch.setattr(working_status_module.time, "monotonic", lambda: now)
+    console = Console(record=True, width=120, force_terminal=True)
+    ui = ConsoleUI(console=console)
+
+    await ui.print_activity("LinuxAgent 正在列目录 /LinuxAgent")
+    now = 103.0
+    await ui.print_activity("LinuxAgent 无法读取文件 /etc/ansible/hosts\n  denied")
+    await ui.print_activity("LinuxAgent 正在整理目录 /LinuxAgent\n  list_dir · 36 items")
+
+    assert ui._working_status is not None
+    render_console = Console(record=True, width=120)
+    render_console.print(ui._working_status._render())
+    rendered = render_console.export_text()
+    assert "处理中（3s • esc 中断）" in rendered
+    assert "整理目录 /LinuxAgent" in rendered
+    ui.clear_activity()
+
+
+async def test_console_print_activity_keeps_tool_failure_in_working_status(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    now = 100.0
+    monkeypatch.setattr(console_module.time, "monotonic", lambda: now)
+    monkeypatch.setattr(working_status_module.time, "monotonic", lambda: now)
+    console = Console(record=True, width=120, force_terminal=True)
+    ui = ConsoleUI(console=console)
+
+    await ui.print_activity("LinuxAgent 正在读取文件 /etc/ansible/hosts")
+    now = 102.0
+    await ui.print_activity("LinuxAgent 无法读取文件 /etc/ansible/hosts\n  denied")
+
+    assert ui._working_status is not None
+    render_console = Console(record=True, width=120)
+    render_console.print(ui._working_status._render())
+    rendered = render_console.export_text()
+    assert "处理中（2s • esc 中断）" in rendered
+    assert "无法读取文件 /etc/ansible/hosts" in rendered
+    assert "denied" in rendered
+    ui.clear_activity()
 
 
 async def test_console_print_active_view_renders_work_items(monkeypatch) -> None:
@@ -883,8 +933,7 @@ async def test_console_print_active_view_renders_work_items(monkeypatch) -> None
     render_console = Console(record=True, width=120)
     render_console.print(ui._working_status._render())
     rendered = render_console.export_text()
-    assert "处理中（esc 中断）" in rendered
-    assert "s • esc 中断" not in rendered
+    assert "处理中（0s • esc 中断）" in rendered
     assert "分类意图" in rendered
     assert "读取文件" in rendered
     assert "/LinuxAgent/.work/plan/PlanC.md" in rendered
@@ -942,6 +991,29 @@ def test_working_status_cancel_skips_live_stop(monkeypatch) -> None:
     assert not live.is_started
 
 
+def test_working_status_limits_multiline_details() -> None:
+    console = Console(record=True, width=120, force_terminal=True)
+    status = WorkingStatus(console)
+
+    status.update(
+        "LinuxAgent 正在并发处理 只读批次：4/4\n"
+        "  - agent A: running\n"
+        "  - agent B: running\n"
+        "  - agent C: running\n"
+        "  - agent D: queued"
+    )
+
+    render_console = Console(record=True, width=120)
+    render_console.print(status._render())
+    rendered = render_console.export_text()
+
+    assert "agent A: running" in rendered
+    assert "agent B: running" in rendered
+    assert "agent C: running..." in rendered
+    assert "agent D: queued" not in rendered
+    status.cancel()
+
+
 def test_working_status_follows_current_stdout(monkeypatch) -> None:
     console = Console(record=True, width=120, force_terminal=True)
     original_file = console._file
@@ -970,7 +1042,7 @@ def test_working_status_does_not_render_prompt_line() -> None:
     status.cancel()
 
 
-def test_working_status_skips_periodic_refresh_for_multiline_view(monkeypatch) -> None:
+def test_working_status_refreshes_multiline_view_timer(monkeypatch) -> None:
     console = Console(record=True, width=120, force_terminal=True)
     status = WorkingStatus(console)
     status.update("LinuxAgent 正在整理目录 /root/.linuxagent\n  list_dir · 17 items")
@@ -987,7 +1059,7 @@ def test_working_status_skips_periodic_refresh_for_multiline_view(monkeypatch) -
 
     status.refresh()
 
-    assert refreshes == 0
+    assert refreshes == 1
     status.cancel()
 
 

--- a/tests/unit/ui/test_prompt_session.py
+++ b/tests/unit/ui/test_prompt_session.py
@@ -28,6 +28,37 @@ def test_prompt_session_manager_builds_dynamic_prompt(tmp_path) -> None:
     assert ("ansibrightmagenta", ">") in prompt()
 
 
+def test_prompt_session_manager_hides_prompt_while_activity_busy(tmp_path) -> None:
+    invalidations = 0
+
+    class _FakeApp:
+        def invalidate(self) -> None:
+            nonlocal invalidations
+            invalidations += 1
+
+    manager = PromptSessionManager(
+        theme="auto",
+        prompt_symbol=">",
+        history_path=tmp_path / "history",
+        session_factory=lambda: SimpleNamespace(
+            default_buffer=SimpleNamespace(text="status"),
+            app=_FakeApp(),
+        ),
+    )
+
+    session = manager.create_session()
+    prompt = manager.dynamic_prompt(session)
+    manager.set_activity_busy(True)
+
+    assert prompt() == []
+    assert invalidations == 1
+
+    manager.set_activity_busy(False)
+
+    assert ("bold ansibrightcyan", "linuxagent") in prompt()
+    assert invalidations == 2
+
+
 def test_prompt_session_manager_default_history_file_is_0600(tmp_path) -> None:
     history_path = tmp_path / "prompt_history"
     manager = PromptSessionManager(


### PR DESCRIPTION
Closes #15

## Summary
- Keep the busy status line visible and elapsed time stable during tool updates and failures.
- Hide the prompt prefix while the agent is busy so `linuxagent ❯` does not flicker.
- Replan Ansible runtime inspections as argv-safe commands instead of attempting to write `/etc/ansible` playbooks.

## Tests
- make lint
- make type
- make test